### PR TITLE
Depth for tree from JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Get help:
 dirstat -h
 ```
 
+### Examples
+
 Run in the current folder, with default settings and JSON output
 
 ```shell
@@ -34,6 +36,24 @@ Statistics over file extensions:
 
 ```shell
 dirstat treemap --svg -x > out.svg
+```
+
+Open the created SVG with the default associated program (ideally a web browser):
+
+```shell
+dirstat treemap --svg > out.svg && out.svg
+```
+
+Exclude files and directories by glob patterns:
+
+```shell
+dirstat -e .git,*.exe
+```
+
+Analyze with a different depth than the default of 2:
+
+```shell
+dirstat -d 4
 ```
 
 ## References

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -94,6 +94,7 @@ func treeFromJSON(file string, exclude []string, depth int) (*tree.FileTree, err
 	if err != nil {
 		return nil, err
 	}
+	t.Crop(depth)
 	return t, nil
 }
 

--- a/cmd/treemap.go
+++ b/cmd/treemap.go
@@ -15,7 +15,7 @@ import (
 // treemapCmd represents the treemap command
 var treemapCmd = &cobra.Command{
 	Use:   "treemap",
-	Short: "Create output in treemap CSV format",
+	Short: "Create output in treemap CSV format or as SVG using treemap",
 	Run: func(cmd *cobra.Command, args []string) {
 		t, err := runRootCommand(cmd, args)
 		if err != nil {

--- a/tree/tree.go
+++ b/tree/tree.go
@@ -32,6 +32,17 @@ func (t *Tree[T]) Aggregate(fn func(parent, child T)) {
 	}
 }
 
+// Crop reduces the tree to a given depth
+func (t *Tree[T]) Crop(depth int) {
+	if depth <= 0 {
+		t.Children = nil
+		return
+	}
+	for _, child := range t.Children {
+		child.Crop(depth - 1)
+	}
+}
+
 // String converts the tree to a multiline string
 func (t *Tree[T]) String() string {
 	return PlainPrinter[T]{}.Print(t)


### PR DESCRIPTION
Allows to read a tree from JSON using a lower depth than was used to originally produce it.

Fixes #3