### PR TITLE
Print proper file tree

### DIFF
--- a/tree/print.go
+++ b/tree/print.go
@@ -60,6 +60,12 @@ const (
 	textWidth  int = 24
 )
 
+var (
+	prefixEmpty  string = "│" + strings.Repeat(" ", textIndent-1)
+	prefixNormal string = "├" + strings.Repeat("─", textIndent-1)
+	prefixLast   string = "└" + strings.Repeat("─", textIndent-1)
+)
+
 func (p FileTreePrinter) print(t *FileTree, sb *strings.Builder, depth int, last bool) {
 	var sizeCount string
 	if t.Value.IsDir {
@@ -119,18 +125,13 @@ func (p FileTreePrinter) printExtensions(ext map[string]*ExtensionEntry, sb *str
 }
 
 func createPrefix(depth, indent int, last bool) string {
-	prefix1 := "│" + strings.Repeat(" ", textIndent-1)
-	var prefix2 string
+	if depth <= 0 {
+		return ""
+	}
 	if last {
-		prefix2 = "└" + strings.Repeat("─", textIndent-1)
-	} else {
-		prefix2 = "├" + strings.Repeat("─", textIndent-1)
+		return strings.Repeat(prefixEmpty, depth-1) + prefixLast
 	}
-	prefix := ""
-	if depth > 0 {
-		prefix = strings.Repeat(prefix1, depth-1) + prefix2
-	}
-	return prefix
+	return strings.Repeat(prefixEmpty, depth-1) + prefixNormal
 }
 
 // TreemapPrinter prints a tree in treemap CSV format

--- a/tree/print.go
+++ b/tree/print.go
@@ -51,14 +51,16 @@ type FileTreePrinter struct {
 // Print prints a FileTree
 func (p FileTreePrinter) Print(t *FileTree) string {
 	sb := strings.Builder{}
-	p.print(t, &sb, 0)
+	p.print(t, &sb, 0, false)
 	return sb.String()
 }
 
-func (p FileTreePrinter) print(t *FileTree, sb *strings.Builder, depth int) {
-	indent := 2
-	width := 24
+const (
+	textIndent int = 2
+	textWidth  int = 24
+)
 
+func (p FileTreePrinter) print(t *FileTree, sb *strings.Builder, depth int, last bool) {
 	var sizeCount string
 	if t.Value.IsDir {
 		sizeCount = fmt.Sprintf("%-7s (%s)",
@@ -68,39 +70,67 @@ func (p FileTreePrinter) print(t *FileTree, sb *strings.Builder, depth int) {
 		sizeCount = fmt.Sprintf("%s", util.FormatUnits(t.Value.Size, "B"))
 	}
 
-	pad := strings.Repeat(" ", int(math.Max(float64(width-depth*indent-len([]rune(t.Value.Name))), 0)))
-	fmt.Fprint(sb, strings.Repeat(" ", depth*indent))
+	prefix := createPrefix(depth, textIndent, last)
+	pad := strings.Repeat(" ", int(math.Max(float64(textWidth-depth*textIndent-len([]rune(t.Value.Name))), 0)))
+	fmt.Fprint(sb, prefix)
 	if t.Value.IsDir {
-		fmt.Fprintf(sb, "-%s %s%s\n", t.Value.Name, pad, sizeCount)
+		fmt.Fprintf(sb, "%s/%s%s\n", t.Value.Name, pad, sizeCount)
 	} else {
-		fmt.Fprintf(sb, " %s %s%s\n", t.Value.Name, pad, sizeCount)
+		fmt.Fprintf(sb, "%s %s%s\n", t.Value.Name, pad, sizeCount)
 	}
-	for _, child := range t.Children {
+	for i, child := range t.Children {
 		if !p.ByExtension || child.Value.IsDir {
-			p.print(child, sb, depth+1)
+			p.print(child, sb, depth+1, i == len(t.Children)-1)
 		}
 	}
 	if p.ByExtension && t.Value.IsDir {
-		keys := make([]string, 0, len(t.Value.Extensions))
-		for k := range t.Value.Extensions {
-			keys = append(keys, k)
-		}
-		sort.Strings(keys)
-
-		for _, name := range keys {
-			info := t.Value.Extensions[name]
-			pad := strings.Repeat(" ", int(math.Max(float64(width-(depth+1)*indent-len([]rune(info.Name))), 0)))
-			fmt.Fprint(sb, strings.Repeat(" ", (depth+1)*indent))
-			fmt.Fprintf(
-				sb,
-				" %s %s%-7s (%s)\n",
-				info.Name,
-				pad,
-				util.FormatUnits(info.Size, "B"),
-				util.FormatUnits(int64(info.Count), ""),
-			)
-		}
+		p.printExtensions(t.Value.Extensions, sb, depth+1)
 	}
+}
+
+func (p FileTreePrinter) printExtensions(ext map[string]*ExtensionEntry, sb *strings.Builder, depth int) {
+	keys := make([]string, 0, len(ext))
+	for k := range ext {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	prefix := createPrefix(depth, textIndent, false)
+	prefixLast := createPrefix(depth, textIndent, true)
+
+	for i, name := range keys {
+		info := ext[name]
+
+		pad := strings.Repeat(" ", int(math.Max(float64(textWidth-(depth)*textIndent-len([]rune(info.Name))), 0)))
+		if i == len(keys)-1 {
+			fmt.Fprint(sb, prefixLast)
+		} else {
+			fmt.Fprint(sb, prefix)
+		}
+		fmt.Fprintf(
+			sb,
+			"%s %s%-7s (%s)\n",
+			info.Name,
+			pad,
+			util.FormatUnits(info.Size, "B"),
+			util.FormatUnits(int64(info.Count), ""),
+		)
+	}
+}
+
+func createPrefix(depth, indent int, last bool) string {
+	prefix1 := "│" + strings.Repeat(" ", textIndent-1)
+	var prefix2 string
+	if last {
+		prefix2 = "└" + strings.Repeat("─", textIndent-1)
+	} else {
+		prefix2 = "├" + strings.Repeat("─", textIndent-1)
+	}
+	prefix := ""
+	if depth > 0 {
+		prefix = strings.Repeat(prefix1, depth-1) + prefix2
+	}
+	return prefix
 }
 
 // TreemapPrinter prints a tree in treemap CSV format


### PR DESCRIPTION
Print file tree with command `plain` like this:

```
./                       97 MB   (25)
├─.github/               3.3 kB  (2)
│ └─workflows/           3.3 kB  (2)
├─cmd/                   10 kB   (3)
│ ├─plain.go             779 B
│ ├─root.go              4.8 kB
│ └─treemap.go           5.2 kB
├─filesys/               4.3 kB  (1)
│ └─walk.go              4.3 kB
├─out/                   65 kB   (1)
│ └─c-data.svg           65 kB
├─tree/                  11 kB   (7)
│ ├─file.go              2.5 kB
│ ├─file_test.go         876 B
│ ├─print.go             5.1 kB
│ ├─serde.go             249 B
│ ├─serde_test.go        427 B
│ ├─tree.go              1.6 kB
│ └─tree_test.go         1.2 kB
├─util/                  1.4 kB  (2)
│ ├─format.go            795 B
│ └─format_test.go       567 B
├─.gitignore             50 B
├─LICENSE                1.1 kB
├─README.md              1.3 kB
├─dirstat.exe            5.2 MB
├─go.mod                 518 B
├─go.sum                 2.9 kB
├─main.go                95 B
├─out.svg                12 kB
└─test.json              92 MB
```