### PR TITLE
Better plain tree

### DIFF
--- a/cmd/plain.go
+++ b/cmd/plain.go
@@ -24,7 +24,7 @@ var plainCmd = &cobra.Command{
 			panic(err)
 		}
 
-		printer := tree.FileTreePrinter{ByExtension: byExt}
+		printer := tree.NewFileTreePrinter(byExt, 2)
 		fmt.Print(printer.Print(t))
 	},
 }

--- a/filesys/walk.go
+++ b/filesys/walk.go
@@ -139,11 +139,8 @@ func walkDirRecursive[T any](path string, d fs.DirEntry, parent *tree.Tree[T], d
 	for _, d1 := range dirs {
 		path1 := filepath.Join(path, d1.Name())
 		_, err := walkDirRecursive(path1, d1, t, depth+1, walkDirFn)
-		if err != nil {
-			if err == filepath.SkipDir {
-				break
-			}
-			return t, err
+		if err != nil && err != filepath.SkipDir {
+			return nil, err
 		}
 	}
 	return t, nil


### PR DESCRIPTION
* Improve tree/branch prefixes
* Auto-determine max width

```
dirstat/.............13 MB   (25)
├─.github/...........3.3 kB  (2)
│ └─workflows/.......3.3 kB  (2)
│   ├─release.yml ...2.6 kB
│   └─tests.yml .....699 B
├─cmd/...............10 kB   (3)
│ ├─plain.go ........772 B
│ ├─root.go .........4.8 kB
│ └─treemap.go ......5.2 kB
```