### PR TITLE
Treemap directory slashes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/gobwas/glob v0.2.3
 	github.com/gookit/color v1.5.2
-	github.com/nikolaydubina/treemap v1.2.3
+	github.com/nikolaydubina/treemap v1.2.4
 	github.com/pkg/profile v1.7.0
 	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
-github.com/nikolaydubina/treemap v1.2.3 h1:ogzjKbszYMxWvFCb3PYczYzVnR8lWyp6kaiCc46MvhE=
-github.com/nikolaydubina/treemap v1.2.3/go.mod h1:8+wLGh917AyeJqBN1D5KM26tv6W/XfvsY+nfJd04/u8=
+github.com/nikolaydubina/treemap v1.2.4 h1:hNjWO32WybPXyZIDGApKu5aHHnHfrF94tVOviqyjnAQ=
+github.com/nikolaydubina/treemap v1.2.4/go.mod h1:8+wLGh917AyeJqBN1D5KM26tv6W/XfvsY+nfJd04/u8=
 github.com/pkg/profile v1.7.0 h1:hnbDkaNWPCLMO9wGLdBFTIZvzDrDfBM2072E1S9gJkA=
 github.com/pkg/profile v1.7.0/go.mod h1:8Uer0jas47ZQMJ7VD+OHknK4YDY07LPUC6dEvqDjvNo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/print/treemap.go
+++ b/print/treemap.go
@@ -48,10 +48,14 @@ func (p TreemapPrinter) print(t *tree.FileTree, sb *strings.Builder, path string
 		sizeCount = fmt.Sprintf("%s", util.FormatUnitsSimple(t.Value.Size, "B"))
 	}
 
+	dirSuffix := ""
+	if t.Value.IsDir {
+		dirSuffix = "&sol;"
+	}
 	if len(path) == 0 {
-		path = fmt.Sprintf("%s (%s)", t.Value.Name, sizeCount)
+		path = fmt.Sprintf("%s%s (%s)", t.Value.Name, dirSuffix, sizeCount)
 	} else {
-		path = fmt.Sprintf("%s/%s (%s)", path, t.Value.Name, sizeCount)
+		path = fmt.Sprintf("%s/%s%s (%s)", path, t.Value.Name, dirSuffix, sizeCount)
 	}
 
 	var v1 float64


### PR DESCRIPTION
Denote directories in treemap by trailing slash.

This uses the solution proposed in https://github.com/nikolaydubina/treemap/pull/27.

Fixes #22 